### PR TITLE
grammatical corrections 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The print(get_* functions has (x,y) ranges, and some equations and print the lin
 
 ### Example:
 ```python
-from tremshape import get_square
+from termshape import get_square
 print(get_square(5,5))
 ```
 so: 
@@ -25,7 +25,7 @@ See below the output.
 
 * Print a square:
 ```python
-from tremshape import get_square
+from termshape import get_square
 print(get_square(5))
 ```
 ```
@@ -38,7 +38,7 @@ print(get_square(5))
 
 * Print a rectangle:
 ```python
-from tremshape import get_rectangle 
+from termshape import get_rectangle 
 print(get_rectangle(10,5))
 ```
 ```
@@ -51,7 +51,7 @@ print(get_rectangle(10,5))
 
 * Print a circle:
 ```python
-from tremshape import get_circle
+from termshape import get_circle
 print(get_circle(10))
 ```
 ```
@@ -80,7 +80,7 @@ print(get_circle(10))
 
 * Print a triangle:
 ```python
-from tremshape import get_triangle
+from termshape import get_triangle
 print(get_triangle(10))
 ```
 ```


### PR DESCRIPTION
In the README.md:

"from tremshape import get_square"
"from tremshape import get_rectangle"
"from tremshape import get_circle"
"from tremshape import get_triangle"

to

"from termshape import get_square"
"from termshape import get_rectangle"
"from termshape import get_circle"
"from termshape import get_triangle"