### PR TITLE
`get_number()` to `get_numbers()`

### DIFF
--- a/termshape/termshape.py
+++ b/termshape/termshape.py
@@ -223,12 +223,12 @@ def get_points(width, height, points, *, fg=DEFAULT_CHARACTER, bg=DEFAULT_BGCHAR
 
     return make_shape(x, y, feqs, beqs, fg=fg, bg=bg)
 
-def get_number(number, size, *, fg=DEFAULT_CHARACTER):
+def get_numbers(number, size, *, fg=DEFAULT_CHARACTER):
     """Creates a shape of numbers.
 
     Positional arguments:
         number - number to print.
-        size - size of the shape.
+        size   - size of the shape.
         
     Keyword arguments:
         fg - foreground character.

--- a/test_termshape.py
+++ b/test_termshape.py
@@ -89,7 +89,7 @@ def test_get_rectangle_background():
 """)
 
 def test_get_numbers():
-	string0 = get_number(0,2)
+	string0 = get_numbers(0,2)
 	assert (string0 == """\
 * * *
 *   *
@@ -98,7 +98,7 @@ def test_get_numbers():
 * * *
 """)
 
-	string1 = get_number(1,2)
+	string1 = get_numbers(1,2)
 	assert (string1 == """\
     *
     *
@@ -107,7 +107,7 @@ def test_get_numbers():
     *
 """)
 
-	string2 = get_number(2,2)
+	string2 = get_numbers(2,2)
 	assert (string2 == """\
 * * *
     *
@@ -116,7 +116,7 @@ def test_get_numbers():
 * * *
 """)
 
-	string3 = get_number(3,2)
+	string3 = get_numbers(3,2)
 	assert (string3 == """\
 * * *
     *
@@ -125,7 +125,7 @@ def test_get_numbers():
 * * *
 """)
 
-	string4 = get_number(4,2)
+	string4 = get_numbers(4,2)
 	assert (string4 == """\
 *   *
 *   *
@@ -134,7 +134,7 @@ def test_get_numbers():
     *
 """)
 
-	string5 = get_number(5,2)
+	string5 = get_numbers(5,2)
 	assert (string5 == """\
 * * *
 *    
@@ -143,7 +143,7 @@ def test_get_numbers():
 * * *
 """)
 
-	string6 = get_number(6,2)
+	string6 = get_numbers(6,2)
 	assert (string6 == """\
 * * *
 *    
@@ -152,7 +152,7 @@ def test_get_numbers():
 * * *
 """)
 
-	string7 = get_number(7,2)
+	string7 = get_numbers(7,2)
 	assert (string7 == """\
 * * *
     *
@@ -161,7 +161,7 @@ def test_get_numbers():
     *
 """)
 
-	string8 = get_number(8,2)
+	string8 = get_numbers(8,2)
 	assert (string8 == """\
 * * *
 *   *
@@ -170,7 +170,7 @@ def test_get_numbers():
 * * *
 """)
 
-	string9 = get_number(9,2)
+	string9 = get_numbers(9,2)
 	assert (string9 == """\
 * * *
 *   *
@@ -179,7 +179,7 @@ def test_get_numbers():
 * * *
 """)
 
-	stringPI = get_number(31415926,3)
+	stringPI = get_numbers(31415926,3)
 	assert (stringPI == """\
 * * * *          *    *     *          *    * * * *    * * * *    * * * *    * * * *
       *          *    *     *          *    *          *     *          *    *      


### PR DESCRIPTION
rename the function `get_number()` to `get_numbers()`.
because in the README.md, the function is `get_numbers()`.